### PR TITLE
调整正则，修复class或id的值如果有换行，无法匹配出正确的class和id值的bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (content, file, options) {
     content = content.replace(/([.#])(?=[^{}]*\{)/ig,"$1" + prev).
               replace(new RegExp('([.#])' + prev + 'G_', 'g'), '$1');
   }else {
-    content = content.replace(/(?:id|class)\s*=\s*(["']?)(.*?)\1/ig, function (n) {
+    content = content.replace(/(?:id|class)\s*=\s*(["']?)([^\1]*?)\1/ig, function (n) {
       return n.replace(/@/g, prev);
     });
     content = content.replace(/@MD-NAME/g, prev);


### PR DESCRIPTION

使用fis3-parse-utc时候，tmpl中如果class值有变量和模块化classname时
```
<% for(var i = 0; i < news.length; i++ ){ var key='sdfsdf'; %>
    <li class="@news-item  <%= key %> swiper-slide swiper-no-swiping"><%= news[i]%></li>
<% } %>  
```

编译后文本中会有换行，如下:
```
<li class="@news-item  '+
((__t=( key ))==null?'':__t)+
' swiper-slide swiper-no-swiping">'+
((__t=( news[i]))==null?'':__t)+
'</li>\n 
```
无法正常解析